### PR TITLE
Refactor: Separate MainLayout into reusable components

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource/roboto": "^5.0.0",
-        "@mui/icons-material": "^5.11.0",
+        "@mui/icons-material": "^5.16.9",
         "@mui/material": "^5.13.0",
         "@mui/x-data-grid": "^6.9.0",
         "react": "^18.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^5.0.0",
-    "@mui/icons-material": "^5.11.0",
+    "@mui/icons-material": "^5.16.9",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.9.0",
     "react": "^18.2.0",

--- a/client/src/layouts/MainLayout.tsx
+++ b/client/src/layouts/MainLayout.tsx
@@ -1,211 +1,42 @@
-import { useState } from 'react';
-import {
-  AppBar,
-  Box,
-  CssBaseline,
-  Drawer,
-  IconButton,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Toolbar,
-  Typography,
-  Badge,
-  Menu,
-  MenuItem,
-  Avatar,
-  TextField,
-} from '@mui/material';
-import {
-  Menu as MenuIcon,
-  Dashboard,
-  Category,
-  Inventory,
-  Business,
-  Person,
-  Notifications as NotificationsIcon,
-} from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
-
-const drawerWidth = 240;
-
-const menuItemsAdmin = [
-  { text: 'Dashboard', icon: <Dashboard />, path: '/dashboard' },
-  { text: 'Catégories', icon: <Category />, path: '/categories' },
-  { text: 'Produits', icon: <Inventory />, path: '/products' },
-  { text: 'Marques', icon: <Business />, path: '/brands' },
-  { text: 'Tags', icon: <Category />, path: '/tags' },
-  { text: 'Caractéristiques', icon: <Category />, path: '/characteristics' },
-  { text: 'Historique', icon: <Category />, path: '/history' },
-];
-
-const menuItemsCollaborator = [
-  { text: 'Dashboard', icon: <Dashboard />, path: '/dashboard' },
-  { text: 'Produits', icon: <Inventory />, path: '/products' },
-  { text: 'Profil', icon: <Person />, path: '/profile' },
-];
+import React, { useState } from 'react';
+import { Box, CssBaseline } from '@mui/material';
+import { AppBarComponent } from './components/AppBarComponent';
+import { DrawerComponent } from './components/DrawerComponent';
+import { menuItemsAdmin, menuItemsCollaborator } from './constants/constants';
 
 const MainLayout = ({
   children,
-  isAdmin = true,
-  // user,
+  isAdmin,
 }: {
   children: React.ReactNode;
   isAdmin: boolean;
-  user: { name: string };
 }) => {
-  const user = {
-    id: 'user123',
-    name: 'John Doe',
-    role: 'admin', // ou 'collaborator'
-  };
-
-  // const notifications = [
-  //   { id: 1, message: 'Nouvelle réponse de la marque A' },
-  //   { id: 2, message: 'Produit X en attente de validation' },
-  //   { id: 3, message: 'Marque Y a répondu à votre demande' },
-  // ];
-
   const [mobileOpen, setMobileOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] =
-    useState<null | HTMLElement>(null);
+    useState<HTMLElement | null>(null);
 
-  const navigate = useNavigate();
-
-  const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen);
-  };
-
-  const handleNotificationsOpen = (event: React.MouseEvent<HTMLElement>) => {
+  const handleDrawerToggle = () => setMobileOpen(!mobileOpen);
+  const handleNotificationsOpen = (event: React.MouseEvent<HTMLElement>) =>
     setNotificationsOpen(event.currentTarget);
-  };
-
-  const handleNotificationsClose = () => {
-    setNotificationsOpen(null);
-  };
-
-  const drawer = (
-    <Box sx={{ mt: 2 }}>
-      <List>
-        {(isAdmin ? menuItemsAdmin : menuItemsCollaborator).map((item) => (
-          <ListItem key={item.text} disablePadding>
-            <ListItemButton onClick={() => navigate(item.path)}>
-              <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.text} />
-            </ListItemButton>
-          </ListItem>
-        ))}
-      </List>
-      {/* Footer dans le Drawer */}
-      <Box sx={{ position: 'absolute', bottom: 0, width: '100%', p: 2 }}>
-        <Typography variant="caption">Version 1.0.0</Typography>
-        <Typography variant="caption">Support : support@example.com</Typography>
-      </Box>
-    </Box>
-  );
+  const handleNotificationsClose = () => setNotificationsOpen(null);
 
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
-      {/* Navbar */}
-      <AppBar
-        position="fixed"
-        sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
-      >
-        <Toolbar>
-          {/* Bouton pour ouvrir le drawer sur mobile */}
-          <IconButton
-            color="inherit"
-            edge="start"
-            onClick={handleDrawerToggle}
-            sx={{ mr: 2, display: { sm: 'none' } }}
-          >
-            <MenuIcon />
-          </IconButton>
-          {/* Titre de la plateforme */}
-          <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
-            PIM Platform
-          </Typography>
-          {/* Barre de recherche globale */}
-          <TextField
-            variant="outlined"
-            size="small"
-            placeholder="Rechercher un produit (nom ou référence)"
-            sx={{ width: 300, mr: 2 }}
-          />
-          {/* Notifications */}
-          <IconButton color="inherit" onClick={handleNotificationsOpen}>
-            <Badge badgeContent={3} color="error">
-              <NotificationsIcon />
-            </Badge>
-          </IconButton>
-          <Menu
-            anchorEl={notificationsOpen}
-            open={Boolean(notificationsOpen)}
-            onClose={handleNotificationsClose}
-          >
-            <MenuItem>Nouvelle réponse de la marque A</MenuItem>
-            <MenuItem>Produit X en attente de validation</MenuItem>
-            <MenuItem>Marque Y a répondu à votre demande</MenuItem>
-          </Menu>
-          {/* Nom de l'utilisateur */}
-          <Typography variant="body2" sx={{ mx: 2 }}>
-            Bonjour, {user.name}
-          </Typography>
-          {/* Avatar utilisateur */}
-          <Avatar alt={user.name} src="/path/to/avatar.jpg" />
-        </Toolbar>
-      </AppBar>
-
-      {/* Drawer */}
-      <Box
-        component="nav"
-        sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
-      >
-        {/* Drawer mobile */}
-        <Drawer
-          variant="temporary"
-          open={mobileOpen}
-          onClose={handleDrawerToggle}
-          ModalProps={{ keepMounted: true }}
-          sx={{
-            display: { xs: 'block', sm: 'none' },
-            '& .MuiDrawer-paper': {
-              boxSizing: 'border-box',
-              width: drawerWidth,
-            },
-          }}
-        >
-          {drawer}
-        </Drawer>
-        {/* Drawer desktop */}
-        <Drawer
-          variant="permanent"
-          sx={{
-            display: { xs: 'none', sm: 'block' },
-            '& .MuiDrawer-paper': {
-              boxSizing: 'border-box',
-              width: drawerWidth,
-              mt: '64px',
-            },
-          }}
-          open
-        >
-          {drawer}
-        </Drawer>
-      </Box>
-
-      {/* Contenu principal */}
-      <Box
-        component="main"
-        sx={{
-          flexGrow: 1,
-          p: 3,
-          mt: '64px',
-        }}
-      >
+      <AppBarComponent
+        user={{ name: 'John Doe' }}
+        notificationsOpen={notificationsOpen}
+        onToggleDrawer={handleDrawerToggle}
+        onNotificationsOpen={handleNotificationsOpen}
+        onNotificationsClose={handleNotificationsClose}
+      />
+      <DrawerComponent
+        isAdmin={isAdmin}
+        menuItems={isAdmin ? menuItemsAdmin : menuItemsCollaborator}
+        mobileOpen={mobileOpen}
+        onClose={handleDrawerToggle}
+      />
+      <Box component="main" sx={{ flexGrow: 1, p: 3, mt: '64px' }}>
         {children}
       </Box>
     </Box>

--- a/client/src/layouts/components/AppBarComponent.tsx
+++ b/client/src/layouts/components/AppBarComponent.tsx
@@ -1,0 +1,77 @@
+import {
+  AppBar,
+  Avatar,
+  Badge,
+  IconButton,
+  TextField,
+  Toolbar,
+  Typography,
+  Menu,
+  MenuItem,
+} from '@mui/material';
+import {
+  Notifications as NotificationsIcon,
+  Menu as MenuIcon,
+} from '@mui/icons-material';
+import React from 'react';
+
+interface AppBarProps {
+  user: { name: string };
+  notificationsOpen: HTMLElement | null;
+  onToggleDrawer: () => void;
+  onNotificationsOpen: (event: React.MouseEvent<HTMLElement>) => void;
+  onNotificationsClose: () => void;
+}
+
+export const AppBarComponent: React.FC<AppBarProps> = ({
+  user,
+  notificationsOpen,
+  onToggleDrawer,
+  onNotificationsOpen,
+  onNotificationsClose,
+}) => {
+  return (
+    <AppBar
+      position="fixed"
+      sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+    >
+      <Toolbar>
+        <IconButton
+          color="inherit"
+          edge="start"
+          onClick={onToggleDrawer}
+          sx={{ mr: 2, display: { sm: 'none' } }}
+        >
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" noWrap sx={{ flexGrow: 1 }}>
+          PIM Platform
+        </Typography>
+        <TextField
+          variant="outlined"
+          size="small"
+          placeholder="Rechercher un produit (nom ou référence)"
+          sx={{ width: 300, mr: 2 }}
+        />
+        <IconButton color="inherit" onClick={onNotificationsOpen}>
+          <Badge badgeContent={3} color="error">
+            <NotificationsIcon />
+          </Badge>
+        </IconButton>
+        <Menu
+          anchorEl={notificationsOpen}
+          open={Boolean(notificationsOpen)}
+          onClose={onNotificationsClose}
+        >
+          <MenuItem>Nouvelle réponse de la marque A</MenuItem>
+          <MenuItem>Produit X en attente de validation</MenuItem>
+          <MenuItem>Marque Y a répondu à votre demande</MenuItem>
+        </Menu>
+        <Typography variant="body2" sx={{ mx: 2 }}>
+          Bonjour, {user.name}
+        </Typography>
+        <Avatar alt={user.name} src="/path/to/avatar.jpg" />
+      </Toolbar>
+    </AppBar>
+  );
+};

--- a/client/src/layouts/components/DrawerComponent.tsx
+++ b/client/src/layouts/components/DrawerComponent.tsx
@@ -1,0 +1,73 @@
+import {
+  Box,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface DrawerProps {
+  isAdmin: boolean;
+  menuItems: { text: string; icon: React.ReactNode; path: string }[];
+  mobileOpen: boolean;
+  onClose: () => void;
+}
+
+export const DrawerComponent: React.FC<DrawerProps> = ({
+  menuItems,
+  mobileOpen,
+  onClose,
+}) => {
+  const navigate = useNavigate();
+
+  const drawerContent = (
+    <Box sx={{ mt: 2 }}>
+      <List>
+        {menuItems.map((item) => (
+          <ListItem key={item.text} disablePadding>
+            <ListItemButton onClick={() => navigate(item.path)}>
+              <ListItemIcon>{item.icon}</ListItemIcon>
+              <ListItemText primary={item.text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+      <Box sx={{ position: 'absolute', bottom: 0, width: '100%', p: 2 }}>
+        <Typography variant="caption">Version 1.0.0</Typography>
+        <Typography variant="caption">Support : support@example.com</Typography>
+      </Box>
+    </Box>
+  );
+
+  return (
+    <>
+      <Drawer
+        variant="temporary"
+        open={mobileOpen}
+        onClose={onClose}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          display: { xs: 'block', sm: 'none' },
+          '& .MuiDrawer-paper': { width: 240 },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: 'none', sm: 'block' },
+          '& .MuiDrawer-paper': { width: 240, mt: '64px' },
+        }}
+        open
+      >
+        {drawerContent}
+      </Drawer>
+    </>
+  );
+};

--- a/client/src/layouts/constants/constants.tsx
+++ b/client/src/layouts/constants/constants.tsx
@@ -1,0 +1,27 @@
+import {
+  Dashboard as DashboardIcon,
+  Category as CategoryIcon,
+  Inventory as InventoryIcon,
+  Business as BusinessIcon,
+  Person as PersonIcon,
+} from '@mui/icons-material';
+
+export const menuItemsAdmin = [
+  { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },
+  { text: 'Catégories', icon: <CategoryIcon />, path: '/categories' },
+  { text: 'Produits', icon: <InventoryIcon />, path: '/products' },
+  { text: 'Marques', icon: <BusinessIcon />, path: '/brands' },
+  { text: 'Tags', icon: <CategoryIcon />, path: '/tags' },
+  {
+    text: 'Caractéristiques',
+    icon: <CategoryIcon />,
+    path: '/characteristics',
+  },
+  { text: 'Historique', icon: <CategoryIcon />, path: '/history' },
+];
+
+export const menuItemsCollaborator = [
+  { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },
+  { text: 'Produits', icon: <InventoryIcon />, path: '/products' },
+  { text: 'Profil', icon: <PersonIcon />, path: '/profile' },
+];

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -5,7 +5,7 @@ const router = createBrowserRouter([
   {
     path: '/',
     element: (
-      <MainLayout>
+      <MainLayout isAdmin={true}>
         <div>Dashboard</div>
       </MainLayout>
     ),


### PR DESCRIPTION
### Changes
- **AppBarComponent**: Extracted the AppBar logic, including search bar, notifications, and user avatar.
- **DrawerComponent**: Centralized the Drawer logic, including both mobile and desktop versions.
- **Constants**: Moved static menu items to a dedicated `constants/constants.ts` file.
- **MainLayout**: Updated to use the new components and constants.

### Benefits
- Improved separation of concerns.
- Easier to test individual components.
- Simplified updates and enhancements to specific parts of the layout.