### PR TITLE
Connect Products API to the frontend

### DIFF
--- a/client/src/components/products/ProductCard.tsx
+++ b/client/src/components/products/ProductCard.tsx
@@ -5,14 +5,14 @@ interface ProductCardProps {
   name: string;
   brand: string;
   price: number;
-  stock: number;
+  status: string;
 }
 
 const ProductCard: React.FC<ProductCardProps> = ({
   name,
   brand,
   price,
-  stock,
+  status,
 }) => {
   return (
     <Card sx={{ minWidth: 275, maxWidth: 300, margin: 2 }}>
@@ -26,8 +26,8 @@ const ProductCard: React.FC<ProductCardProps> = ({
         <Typography variant="body1" sx={{ marginTop: 1 }}>
           Prix: {price} €
         </Typography>
-        <Typography variant="body2" color={stock > 0 ? 'green' : 'red'}>
-          Stock: {stock > 0 ? 'En stock' : 'Rupture de stock'}
+        <Typography variant="body2" color="textSecondary">
+          Status: {status}
         </Typography>
       </CardContent>
     </Card>

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -32,6 +32,35 @@ export type Scalars = {
   DateTimeISO: { input: Date; output: Date };
 };
 
+export type Actions = {
+  __typename?: 'Actions';
+  histories?: Maybe<History>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type Brands = {
+  __typename?: 'Brands';
+  contacts?: Maybe<Array<Contacts>>;
+  createdAt?: Maybe<Scalars['DateTimeISO']['output']>;
+  deletedAt?: Maybe<Scalars['DateTimeISO']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  exchanges?: Maybe<Array<Exchanges>>;
+  id: Scalars['String']['output'];
+  logo?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  products?: Maybe<Array<Products>>;
+  updatedAt?: Maybe<Scalars['DateTimeISO']['output']>;
+};
+
+export type Contacts = {
+  __typename?: 'Contacts';
+  country?: Maybe<Scalars['String']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  phone?: Maybe<Scalars['String']['output']>;
+};
+
 export type DashboardStats = {
   __typename?: 'DashboardStats';
   pendingCommunications: Scalars['Int']['output'];
@@ -39,6 +68,30 @@ export type DashboardStats = {
   productsByCategory: Array<ProductStat>;
   recentHistory: Array<HistoryEntry>;
   totalProducts: Scalars['Int']['output'];
+};
+
+export type Exchanges = {
+  __typename?: 'Exchanges';
+  brand?: Maybe<Brands>;
+  brandId?: Maybe<Scalars['String']['output']>;
+  closedAt?: Maybe<Scalars['DateTimeISO']['output']>;
+  createdAt?: Maybe<Scalars['DateTimeISO']['output']>;
+  id: Scalars['String']['output'];
+  message: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  user?: Maybe<Users>;
+  userId?: Maybe<Scalars['String']['output']>;
+};
+
+export type History = {
+  __typename?: 'History';
+  action: Actions;
+  createdAt?: Maybe<Scalars['DateTimeISO']['output']>;
+  id: Scalars['String']['output'];
+  product: Products;
+  productId: Scalars['String']['output'];
+  user: Users;
+  userId: Scalars['String']['output'];
 };
 
 export type HistoryEntry = {
@@ -55,6 +108,7 @@ export type ProductStat = {
 
 export type Products = {
   __typename?: 'Products';
+  brand: Brands;
   brandId: Scalars['String']['output'];
   createdAt?: Maybe<Scalars['DateTimeISO']['output']>;
   deletedAt?: Maybe<Scalars['DateTimeISO']['output']>;
@@ -62,7 +116,7 @@ export type Products = {
   id: Scalars['String']['output'];
   label?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
-  price: Scalars['String']['output'];
+  price: Scalars['Float']['output'];
   reference: Scalars['String']['output'];
   shortDescription?: Maybe<Scalars['String']['output']>;
   status: Scalars['String']['output'];
@@ -73,6 +127,29 @@ export type Query = {
   __typename?: 'Query';
   dashboardStats: DashboardStats;
   products: Array<Products>;
+};
+
+export type QueryProductsArgs = {
+  limit?: Scalars['Int']['input'];
+  page?: Scalars['Int']['input'];
+};
+
+export type Users = {
+  __typename?: 'Users';
+  createdAt?: Maybe<Scalars['DateTimeISO']['output']>;
+  deletedAt?: Maybe<Scalars['DateTimeISO']['output']>;
+  email: Scalars['String']['output'];
+  endDate?: Maybe<Scalars['DateTimeISO']['output']>;
+  exchanges?: Maybe<Array<Exchanges>>;
+  firstName: Scalars['String']['output'];
+  histories?: Maybe<Array<History>>;
+  id: Scalars['String']['output'];
+  isAdmin: Scalars['Boolean']['output'];
+  lastName: Scalars['String']['output'];
+  password: Scalars['String']['output'];
+  phone?: Maybe<Scalars['String']['output']>;
+  startDate?: Maybe<Scalars['DateTimeISO']['output']>;
+  updatedAt?: Maybe<Scalars['DateTimeISO']['output']>;
 };
 
 export type DashboardStatsQueryVariables = Exact<{ [key: string]: never }>;
@@ -99,6 +176,27 @@ export type DashboardStatsQuery = {
       createdAt: Date;
     }>;
   };
+};
+
+export type GetProductsQueryVariables = Exact<{
+  page?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+export type GetProductsQuery = {
+  __typename?: 'Query';
+  products: Array<{
+    __typename?: 'Products';
+    id: string;
+    name: string;
+    reference: string;
+    price: number;
+    status: string;
+    label?: string | null;
+    createdAt?: Date | null;
+    brand: { __typename?: 'Brands'; name: string };
+  }>;
+  dashboardStats: { __typename?: 'DashboardStats'; totalProducts: number };
 };
 
 export const DashboardStatsDocument = gql`
@@ -190,4 +288,93 @@ export type DashboardStatsSuspenseQueryHookResult = ReturnType<
 export type DashboardStatsQueryResult = Apollo.QueryResult<
   DashboardStatsQuery,
   DashboardStatsQueryVariables
+>;
+export const GetProductsDocument = gql`
+  query GetProducts($page: Int, $limit: Int) {
+    products(page: $page, limit: $limit) {
+      id
+      name
+      reference
+      price
+      status
+      label
+      createdAt
+      brand {
+        name
+      }
+    }
+    dashboardStats {
+      totalProducts
+    }
+  }
+`;
+
+/**
+ * __useGetProductsQuery__
+ *
+ * To run a query within a React component, call `useGetProductsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetProductsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetProductsQuery({
+ *   variables: {
+ *      page: // value for 'page'
+ *      limit: // value for 'limit'
+ *   },
+ * });
+ */
+export function useGetProductsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetProductsQuery,
+    GetProductsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetProductsQuery, GetProductsQueryVariables>(
+    GetProductsDocument,
+    options
+  );
+}
+export function useGetProductsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetProductsQuery,
+    GetProductsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetProductsQuery, GetProductsQueryVariables>(
+    GetProductsDocument,
+    options
+  );
+}
+export function useGetProductsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetProductsQuery,
+        GetProductsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<GetProductsQuery, GetProductsQueryVariables>(
+    GetProductsDocument,
+    options
+  );
+}
+export type GetProductsQueryHookResult = ReturnType<typeof useGetProductsQuery>;
+export type GetProductsLazyQueryHookResult = ReturnType<
+  typeof useGetProductsLazyQuery
+>;
+export type GetProductsSuspenseQueryHookResult = ReturnType<
+  typeof useGetProductsSuspenseQuery
+>;
+export type GetProductsQueryResult = Apollo.QueryResult<
+  GetProductsQuery,
+  GetProductsQueryVariables
 >;

--- a/client/src/graphql/products.ts
+++ b/client/src/graphql/products.ts
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client';
+
+export const GET_PRODUCTS = gql`
+  query GetProducts($page: Int, $limit: Int) {
+    products(page: $page, limit: $limit) {
+      id
+      name
+      reference
+      price
+      status
+      label
+      createdAt
+      brand {
+        name
+      }
+    }
+    dashboardStats {
+      totalProducts
+    }
+  }
+`;

--- a/client/src/layouts/constants/constants.tsx
+++ b/client/src/layouts/constants/constants.tsx
@@ -8,9 +8,9 @@ import {
 
 export const menuItemsAdmin = [
   { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },
-  { text: 'Catégories', icon: <CategoryIcon />, path: '/categories' },
   { text: 'Produits', icon: <InventoryIcon />, path: '/products' },
   { text: 'Marques', icon: <BusinessIcon />, path: '/brands' },
+  { text: 'Catégories', icon: <CategoryIcon />, path: '/categories' },
   { text: 'Tags', icon: <CategoryIcon />, path: '/tags' },
   {
     text: 'Caractéristiques',

--- a/client/src/pages/ProductsPage.tsx
+++ b/client/src/pages/ProductsPage.tsx
@@ -2,16 +2,6 @@ import React from 'react';
 import ProductList from '../components/products/ProductList';
 import { Box, Grid, Typography } from '@mui/material';
 
-export const mockProducts = [
-  { id: '1', name: 'Produit 1', brand: 'Marque A', price: 50, stock: 10 },
-  { id: '2', name: 'Produit 2', brand: 'Marque B', price: 70, stock: 0 },
-  { id: '3', name: 'Produit 3', brand: 'Marque C', price: 30, stock: 5 },
-  { id: '4', name: 'Produit 4', brand: 'Marque A', price: 20, stock: 2 },
-  { id: '5', name: 'Produit 5', brand: 'Marque D', price: 60, stock: 8 },
-  { id: '6', name: 'Produit 6', brand: 'Marque B', price: 100, stock: 1 },
-  { id: '7', name: 'Produit 7', brand: 'Marque E', price: 40, stock: 3 },
-];
-
 const ProductsPage: React.FC = () => {
   const drawerWidth = 240;
   return (
@@ -25,7 +15,7 @@ const ProductsPage: React.FC = () => {
         Liste des produits
       </Typography>
       <Grid container spacing={2}>
-        <ProductList products={mockProducts} />
+        <ProductList />
       </Grid>
     </Box>
   );

--- a/services/graphql-service/src/entities/Products.ts
+++ b/services/graphql-service/src/entities/Products.ts
@@ -16,7 +16,7 @@ import { Images } from './Images';
 import { Brands } from './Brands';
 import { Categories } from './Categories';
 import { Tags } from './Tags';
-import { Field, ObjectType } from 'type-graphql';
+import { Field, Float, ObjectType } from 'type-graphql';
 
 @ObjectType()
 @Index('idx_products_brand', ['brandId'], {})
@@ -54,9 +54,17 @@ export class Products extends BaseEntity {
   @Column('text', { name: 'description', nullable: true })
   description: string | null;
 
-  @Field(() => String)
   @Column('numeric', { name: 'price', precision: 10, scale: 2 })
-  price: string;
+  private _price: string;
+
+  @Field(() => Float)
+  get price(): number {
+    return parseFloat(this._price);
+  }
+
+  set price(value: number) {
+    this._price = value.toFixed(2);
+  }
 
   @Field(() => String)
   @Column('character varying', {
@@ -109,6 +117,7 @@ export class Products extends BaseEntity {
   @ManyToMany(() => Images, (images) => images.products)
   images: Images[];
 
+  @Field(() => Brands)
   @ManyToOne(() => Brands, (brands) => brands.products)
   @JoinColumn([{ name: 'brand_id', referencedColumnName: 'id' }])
   brand: Brands;

--- a/services/graphql-service/src/resolvers/ProductResolver.ts
+++ b/services/graphql-service/src/resolvers/ProductResolver.ts
@@ -1,13 +1,21 @@
-import { Resolver, Query } from 'type-graphql';
+import { Resolver, Query, Arg, Int } from 'type-graphql';
 import { Products } from '../entities/Products';
 
 @Resolver(Products)
 export default class ProductsResolver {
   @Query(() => [Products])
-  async products(): Promise<Products[]> {
+  async products(
+    @Arg('page', () => Int, { defaultValue: 1 }) page: number,
+    @Arg('limit', () => Int, { defaultValue: 10 }) limit: number
+  ): Promise<Products[]> {
     try {
-      // Utilisation de TypeORM pour récupérer tous les produits
-      return await Products.find();
+      const offset = (page - 1) * limit;
+      return await Products.find({
+        skip: offset,
+        take: limit,
+        order: { createdAt: 'DESC' },
+        relations: ['brand'],
+      });
     } catch (error) {
       console.error('Error fetching products:', error);
       throw new Error('Unable to fetch products');


### PR DESCRIPTION
### Description
This PR connects the Products API to the frontend, enabling real-time fetching and display of paginated product data in the ProductList component. The integration includes type-safe handling of price conversion and brand details.

### Changes
- **API Integration:**
  - Used Apollo Client to query the `products` endpoint with pagination.
  - Hooked up the `ProductList` component to live API data.
- **Entity Update:**
  - Added a getter for `price` in the Products entity to convert the DB-stored `string` to a GraphQL `number`.
- **Resolver Update:**
  - Updated the ProductsResolver to utilize the `price` getter for type consistency.
- **Pagination:**
  - Added support for API-side pagination in the frontend.
- **UI Update:**
  - Updated the `ProductCard` component to dynamically render product data, including name, brand, and price.
