### PR TITLE
Feature/brands img connect

### DIFF
--- a/client/src/components/brands/BrandCard.tsx
+++ b/client/src/components/brands/BrandCard.tsx
@@ -34,7 +34,9 @@ const BrandCard: React.FC<BrandCardProps> = ({
       <CardMedia
         component="img"
         height="120"
-        image={logo || '/api/placeholder/180/120'}
+        image={
+          `http://localhost:8000/logos/${logo}` || '/api/placeholder/180/120'
+        }
         alt={`${name} logo`}
         sx={{ objectFit: 'contain', p: 2, bgcolor: 'grey.50' }}
       />
@@ -42,6 +44,7 @@ const BrandCard: React.FC<BrandCardProps> = ({
         <Typography variant="h6" gutterBottom>
           {name}
         </Typography>
+        <Typography>{logo}</Typography>
         <Typography variant="body2" color="textSecondary">
           {description}
         </Typography>

--- a/client/src/components/brands/BrandList.tsx
+++ b/client/src/components/brands/BrandList.tsx
@@ -46,7 +46,27 @@ const BrandList: React.FC = () => {
         placeholder="Rechercher une marque..."
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
-        sx={{ mb: 3 }}
+        sx={{
+          width: 400,
+          mb: 3,
+          bgcolor: 'white',
+          '& .MuiInputBase-input::placeholder': {
+            color: 'grey.500', // Couleur du placeholder
+            opacity: 1, // Assure que le placeholder est visible
+          },
+          borderRadius: 1, // Arrondi des bordures
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'grey.500', // Couleur de la bordure
+            },
+            '&:hover fieldset': {
+              borderColor: 'black', // Couleur au survol
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: 'primary.main', // Couleur au focus
+            },
+          },
+        }}
       />
 
       {/* Liste des marques */}

--- a/client/src/components/products/ProductCard.tsx
+++ b/client/src/components/products/ProductCard.tsx
@@ -17,7 +17,16 @@ const ProductCard: React.FC<ProductCardProps> = ({
   reference,
 }) => {
   return (
-    <Card sx={{ minWidth: 275, maxWidth: 300, margin: 2 }}>
+    <Card
+      sx={{
+        minWidth: 275,
+        maxWidth: 300,
+        margin: 2,
+        '&:hover': {
+          boxShadow: 6,
+        },
+      }}
+    >
       <CardContent>
         <Typography variant="h6" gutterBottom>
           {name}

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -69,6 +69,9 @@ services:
       - '8000:80' # Expose NGINX sur le port 8000
     volumes:
       - ../../nginx.conf:/etc/nginx/nginx.conf:ro # Monte le fichier nginx.conf
+      - ../../storage/assets/images:/storage/assets/images # Monte les assets
+      - ../../storage/assets/logos:/storage/assets/logos # Monte les assets
+
     depends_on:
       - client
       - api

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,5 +19,16 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+
+         # Servir les assets
+        location /images {
+            alias /storage/assets/images;
+            autoindex on; # Optionnel : permet d'afficher le contenu du dossier
+        }
+
+        location /logos {
+            alias /storage/assets/logos;
+            autoindex on; # Optionnel : permet d'afficher le contenu du dossier
+        }
     }
 }


### PR DESCRIPTION
# Pull Request : Connecter le logo des cartes `Brand` avec les assets

## Description
Cette PR permet d'afficher les logos des marques dans le composant `BrandCard`. Les logos sont récupérés via le champ `logo` de la base de données, et les fichiers correspondants sont servis par Nginx à partir du volume `storage/assets`.

## Changements apportés
1. **Frontend :**
   - Mise à jour du composant `BrandCard` pour construire dynamiquement l'URL des logos :  
     `http://localhost:8000/assets/logos/${logo}`.
   - Ajout d'un logo par défaut en cas d'absence de logo pour une marque.

2. **Infra :**
   - Ajout du montage du volume `storage/assets` dans Docker Compose pour le conteneur Nginx.
   - Mise à jour de `nginx.conf` pour servir les assets via l'URL `/assets/`.