### PR TITLE
feat(brands): make entire brand card clickable and remove details button

### DIFF
--- a/client/src/components/brands/BrandCard.tsx
+++ b/client/src/components/brands/BrandCard.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Box,
   Chip,
-  Button,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 
@@ -25,14 +24,19 @@ const BrandCard: React.FC<BrandCardProps> = ({
   totalProducts,
 }) => {
   const navigate = useNavigate();
+
   return (
     <Card
+      onClick={() => navigate(`/brands/${id}`)}
       sx={{
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+        cursor: 'pointer',
+        transition: 'all 0.2s ease-in-out',
         '&:hover': {
           boxShadow: 6,
+          transform: 'translateY(-4px)',
         },
       }}
     >
@@ -46,20 +50,34 @@ const BrandCard: React.FC<BrandCardProps> = ({
         sx={{ objectFit: 'contain', p: 2, bgcolor: 'grey.50' }}
       />
       <CardContent sx={{ flexGrow: 1 }}>
-        <Typography variant="h6" gutterBottom>
+        <Typography
+          variant="h6"
+          gutterBottom
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+          }}
+        >
           {name}
         </Typography>
-        <Typography variant="body2" color="textSecondary">
+        <Typography
+          variant="body2"
+          color="textSecondary"
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            mb: 2,
+          }}
+        >
           {description}
         </Typography>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={() => navigate(`/brands/${id}`)}
-        >
-          Voir les détails
-        </Button>
-        <Box sx={{ mt: 2 }}>
+        <Box sx={{ mt: 'auto' }}>
           <Chip
             label={`${totalProducts} produits`}
             size="small"


### PR DESCRIPTION
# Make entire brand card clickable and improve UX

## Description
This PR modifies the BrandCard component to make the entire card clickable instead of using a dedicated "View Details" button. This change improves the user experience by increasing the clickable area and simplifying the interface.

## Changes
- Remove "View Details" button
- Make the entire card clickable
- Add hover animation and visual feedback
- Improve text overflow handling
- Better spacing organization

## Visual Changes
- Added a subtle lift animation on hover
- Improved text truncation with ellipsis
- Removed the button for a cleaner look
- Chip position is now consistently at the bottom