### PR TITLE
Feature/brand contact products count

### DIFF
--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -56,8 +56,8 @@ export type Brands = {
 };
 
 export type BrandsContactsArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
+  contactLimit?: InputMaybe<Scalars['Int']['input']>;
+  contactOffset?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type Categories = {
@@ -85,6 +85,7 @@ export type Contacts = {
   id: Scalars['String']['output'];
   phone?: Maybe<Scalars['String']['output']>;
   products: Products;
+  totalProducts: Scalars['Int']['output'];
   updatedAt?: Maybe<Scalars['DateTimeISO']['output']>;
 };
 
@@ -308,6 +309,7 @@ export type GetBrandQuery = {
       email?: string | null;
       phone?: string | null;
       country?: string | null;
+      totalProducts: number;
     }>;
     products?: Array<{
       __typename?: 'Products';
@@ -542,17 +544,18 @@ export const GetBrandDocument = gql`
       logo
       description
       totalProducts
-      contacts(limit: $contactLimit, offset: $contactOffset) {
+      totalContacts
+      contacts(contactLimit: $contactLimit, contactOffset: $contactOffset) {
         id
         email
         phone
         country
+        totalProducts
       }
       products {
         id
         name
       }
-      totalContacts
     }
   }
 `;

--- a/client/src/graphql/brands.ts
+++ b/client/src/graphql/brands.ts
@@ -32,17 +32,18 @@ export const GET_BRAND = gql`
       logo
       description
       totalProducts
-      contacts(limit: $contactLimit, offset: $contactOffset) {
+      totalContacts
+      contacts(contactLimit: $contactLimit, contactOffset: $contactOffset) {
         id
         email
         phone
         country
+        totalProducts
       }
       products {
         id
         name
       }
-      totalContacts
     }
   }
 `;

--- a/client/src/pages/BandDetailsPage.tsx
+++ b/client/src/pages/BandDetailsPage.tsx
@@ -12,6 +12,7 @@ import {
   TablePagination,
   Paper,
   Card,
+  Chip,
 } from '@mui/material';
 import { useGetBrandQuery } from '../generated/graphql-types';
 
@@ -29,6 +30,8 @@ const BrandDetailsPage: React.FC = () => {
     skip: !id,
   });
 
+  const brand = data?.brand;
+
   if (!id) {
     return (
       <Typography color="error">Error: ID is missing from the URL.</Typography>
@@ -38,8 +41,6 @@ const BrandDetailsPage: React.FC = () => {
   if (loading) return <Typography>Loading...</Typography>;
   if (error)
     return <Typography color="error">Error: {error.message}</Typography>;
-
-  const brand = data?.brand;
 
   const handlePageChange = (event: unknown, newPage: number) => {
     setPage(newPage);
@@ -61,6 +62,12 @@ const BrandDetailsPage: React.FC = () => {
       contactLimit: newRowsPerPage,
       contactOffset: 0,
     });
+  };
+
+  const getProductCountColor = (count: number) => {
+    if (count === 0) return 'default';
+    if (count < 6) return 'warning';
+    return 'success';
   };
 
   const drawerWidth = 240;
@@ -133,11 +140,11 @@ const BrandDetailsPage: React.FC = () => {
                 <TableCell>{contact.phone}</TableCell>
                 <TableCell>{contact.country}</TableCell>
                 <TableCell align="center">
-                  {
-                    brand?.products?.filter((product) =>
-                      product.name.includes(contact.country || '')
-                    ).length
-                  }
+                  <Chip
+                    label={contact.totalProducts}
+                    color={getProductCountColor(contact.totalProducts)}
+                    size="small"
+                  />
                 </TableCell>
               </TableRow>
             ))}

--- a/services/graphql-service/src/entities/Contacts.ts
+++ b/services/graphql-service/src/entities/Contacts.ts
@@ -9,7 +9,7 @@ import {
 } from 'typeorm';
 import { Brands } from './Brands';
 import { Products } from './Products';
-import { Field, GraphQLISODateTime, ObjectType } from 'type-graphql';
+import { Field, GraphQLISODateTime, Int, ObjectType } from 'type-graphql';
 
 @ObjectType()
 @Index('contacts_brand_id_country_email_key', ['brandId', 'country', 'email'], {
@@ -76,4 +76,12 @@ export class Contacts extends BaseEntity {
   @Field(() => Products)
   @OneToMany(() => Products, (products) => products.contact)
   products: Products[];
+
+  @Field(() => Int)
+  async totalProducts(): Promise<number> {
+    const count = await Products.count({
+      where: { contact: { id: this.id } },
+    });
+    return count;
+  }
 }

--- a/services/graphql-service/src/index.ts
+++ b/services/graphql-service/src/index.ts
@@ -5,6 +5,7 @@ import { AppDataSource } from './config/database';
 import ProductsResolver from './resolvers/ProductResolver';
 import { BrandResolver } from './resolvers/BrandResolver';
 import { DashboardResolver } from './resolvers/DashboardResolver';
+import { ContactResolver } from './resolvers/ContactResolver';
 
 async function bootstrap() {
   // Initialisation de la base de données
@@ -13,7 +14,12 @@ async function bootstrap() {
 
   // Construction du schéma GraphQL
   const schema = await buildSchema({
-    resolvers: [ProductsResolver, BrandResolver, DashboardResolver],
+    resolvers: [
+      ProductsResolver,
+      BrandResolver,
+      DashboardResolver,
+      ContactResolver,
+    ],
     validate: false,
   });
 

--- a/services/graphql-service/src/resolvers/BrandResolver.ts
+++ b/services/graphql-service/src/resolvers/BrandResolver.ts
@@ -39,13 +39,13 @@ export class BrandResolver {
   @FieldResolver(() => [Contacts])
   async contacts(
     @Root() brand: Brands,
-    @Arg('limit', () => Int, { nullable: true }) limit?: number,
-    @Arg('offset', () => Int, { nullable: true }) offset?: number
+    @Arg('contactLimit', () => Int, { nullable: true }) contactLimit?: number,
+    @Arg('contactOffset', () => Int, { nullable: true }) contactOffset?: number
   ): Promise<Contacts[]> {
     return await Contacts.find({
       where: { brand: { id: brand.id } },
-      take: limit || 10, // Limite par défaut
-      skip: offset || 0,
+      take: contactLimit || 5,
+      skip: contactOffset || 0,
     });
   }
 

--- a/services/graphql-service/src/resolvers/ContactResolver.ts
+++ b/services/graphql-service/src/resolvers/ContactResolver.ts
@@ -1,0 +1,13 @@
+import { FieldResolver, Resolver, Root } from 'type-graphql';
+import { Contacts } from '../entities/Contacts';
+import { Products } from '../entities/Products';
+
+@Resolver(Contacts)
+export class ContactResolver {
+  @FieldResolver(() => Number)
+  async totalProducts(@Root() contact: Contacts): Promise<number> {
+    return await Products.count({
+      where: { contact: { id: contact.id } },
+    });
+  }
+}


### PR DESCRIPTION
# Ajout du compte des produits par contact

## Description
Cette PR ajoute la possibilité de voir le nombre de produits associés à chaque contact dans la vue détaillée d'une marque.

## Changements
- Ajout du champ `productsCount` dans l'entité Contact
- Création d'un FieldResolver pour calculer le nombre de produits
- Intégration du resolver dans le schéma Apollo