### PR TITLE
fix(categories): correct dialog labels for create/edit mode

### DIFF
--- a/client/src/pages/CategoriesPage.tsx
+++ b/client/src/pages/CategoriesPage.tsx
@@ -241,7 +241,7 @@ const CategoriesPage = () => {
         fullWidth
       >
         <DialogTitle>
-          {name ? 'Modifier la catégorie' : 'Nouvelle catégorie'}
+          {editingCategory ? 'Modifier la catégorie' : 'Nouvelle catégorie'}
         </DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 2 }}>
@@ -266,7 +266,7 @@ const CategoriesPage = () => {
         <DialogActions>
           <Button onClick={handleCloseDialog}>Annuler</Button>
           <Button onClick={handleSubmit} variant="contained" disabled={loading}>
-            {name ? 'Modifier' : 'Créer'}
+            {editingCategory ? 'Modifier' : 'Créer'}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Fix Category Dialog Labels

### Description
This PR fixes an issue where the category dialog labels would incorrectly change from "Create" to "Edit" when typing in the name field.

### Changes
- Update dialog title to use `editingCategory` state instead of `name`
- Fix submit button label to correctly reflect create/edit mode
- Ensure consistent labeling throughout the dialog

### Technical Details
- Use `editingCategory` state as the source of truth for dialog mode
- Remove dependency on input field values for determining dialog mode
