### PR TITLE
feat(filters): replace brand autocomplete with single-select filter

### DIFF
--- a/client/src/components/products/ProductList.tsx
+++ b/client/src/components/products/ProductList.tsx
@@ -9,9 +9,14 @@ import { getStatusLabel } from '../../utils/product.utils';
 interface ProductListProps {
   searchQuery?: string; // Recherche optionnelle
   status?: string; // Filtre optionnel
+  brandId?: string; // Filtre optionnel
 }
 
-const ProductList: React.FC<ProductListProps> = ({ searchQuery, status }) => {
+const ProductList: React.FC<ProductListProps> = ({
+  searchQuery,
+  status,
+  brandId,
+}) => {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 12;
 
@@ -21,12 +26,13 @@ const ProductList: React.FC<ProductListProps> = ({ searchQuery, status }) => {
       limit: itemsPerPage,
       query: searchQuery,
       status: status,
+      brandId: brandId,
     },
   });
 
   // Gestion de la pagination
   const handlePageChange = (
-    event: React.ChangeEvent<unknown>,
+    _event: React.ChangeEvent<unknown>,
     page: number
   ) => {
     setCurrentPage(page);

--- a/client/src/components/products/ProductTableView.tsx
+++ b/client/src/components/products/ProductTableView.tsx
@@ -28,11 +28,13 @@ import { getStatusLabel } from '../../utils/product.utils';
 interface ProductTableViewProps {
   searchQuery?: string;
   status?: string;
+  brandId?: string;
 }
 
 const ProductTableView: React.FC<ProductTableViewProps> = ({
   searchQuery,
   status,
+  brandId,
 }) => {
   const navigate = useNavigate();
   const { confirmDelete } = useDialog();
@@ -47,8 +49,8 @@ const ProductTableView: React.FC<ProductTableViewProps> = ({
       limit: itemsPerPage,
       query: searchQuery,
       status: status,
+      brandId: brandId || null,
     },
-    fetchPolicy: 'network-only', // Toujours récupérer les nouvelles données
     notifyOnNetworkStatusChange: true,
   });
 
@@ -64,7 +66,7 @@ const ProductTableView: React.FC<ProductTableViewProps> = ({
 
   // Changement de page
   const handlePageChange = (
-    event: React.ChangeEvent<unknown>,
+    _event: React.ChangeEvent<unknown>,
     page: number
   ) => {
     setCurrentPage(page);

--- a/client/src/components/products/filters/BrandFilter.tsx
+++ b/client/src/components/products/filters/BrandFilter.tsx
@@ -1,49 +1,49 @@
-// components/products/filters/BrandFilter.tsx
 import { FC } from 'react';
-
-import { Autocomplete, TextField } from '@mui/material';
+import { FormControl, Select, MenuItem, Box } from '@mui/material';
 import { useGetBrandsForFilterQuery } from '../../../generated/graphql-types';
 
 interface BrandFilterProps {
-  selectedBrands: string[];
-  onChange: (selectedBrands: string[]) => void;
+  value: string | '';
+  onChange: (value: string | '') => void;
 }
 
-export const BrandFilter: FC<BrandFilterProps> = ({
-  selectedBrands,
-  onChange,
-}) => {
+export const BrandFilter: FC<BrandFilterProps> = ({ value, onChange }) => {
   const { data } = useGetBrandsForFilterQuery();
-
-  const selectedBrandObjects = (data?.brandsForFilter || []).filter((brand) =>
-    selectedBrands.includes(brand.id)
-  );
+  const brands = data?.brandsForFilter || [];
 
   return (
-    <Autocomplete
-      multiple
-      value={selectedBrandObjects}
-      onChange={(_, newValue) => {
-        onChange(newValue.map((brand) => brand.id));
-      }}
-      options={data?.brandsForFilter || []}
-      getOptionLabel={(option) => option.name}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          // label="Marques"
-          size="small"
-          placeholder={'Sélectionner une ou plusieurs marques'}
-        />
-      )}
-      noOptionsText="Aucune marque trouvée"
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        boxShadow: 1,
-        minWidth: 340,
-        outline: 'none',
-      }}
-    />
+    <FormControl size="small" sx={{ minWidth: 200, borderRadius: '8px' }}>
+      <Select
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value as string);
+        }}
+        displayEmpty
+        renderValue={(selected) =>
+          selected ? (
+            <Box
+              sx={{ display: 'flex', alignItems: 'center', minHeight: '40px' }}
+            >
+              {brands.find((brand) => brand.id === selected)?.name || 'Marque'}
+            </Box>
+          ) : (
+            <Box
+              sx={{ display: 'flex', alignItems: 'center', minHeight: '40px' }}
+            >
+              <span style={{ color: 'gray', opacity: 0.5 }}>Marque</span>
+            </Box>
+          )
+        }
+      >
+        <MenuItem value="">
+          <em>Toutes</em>
+        </MenuItem>
+        {brands.map((brand) => (
+          <MenuItem key={brand.id} value={brand.id}>
+            {brand.name}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
 };

--- a/client/src/components/products/filters/FilterContainer.tsx
+++ b/client/src/components/products/filters/FilterContainer.tsx
@@ -17,10 +17,11 @@ export const FilterContainer: React.FC<FilterContainerProps> = ({
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
+  // Adapter le type de `brandId` pour être une seule valeur `string | ''`
   const [filters, setFilters] = useState<FilterState>({
     searchQuery: searchParams.get('query') || undefined,
     status: '',
-    brandIds: [],
+    brandId: '',
     ...initialFilters,
   });
 
@@ -44,9 +45,9 @@ export const FilterContainer: React.FC<FilterContainerProps> = ({
   };
 
   const handleResetSearch = () => {
-    searchParams.delete('query'); // Supprime le paramètre "query" de l'URL
+    searchParams.delete('query');
     navigate({
-      pathname: '/products', // Navigue vers /products sans paramètres
+      pathname: '/products',
       search: searchParams.toString(),
     });
   };
@@ -60,8 +61,8 @@ export const FilterContainer: React.FC<FilterContainerProps> = ({
             onChange={(status) => handleFilterChange({ status })}
           />
           <BrandFilter
-            selectedBrands={filters.brandIds}
-            onChange={(brandIds) => handleFilterChange({ brandIds })}
+            value={filters.brandId}
+            onChange={(brandId) => handleFilterChange({ brandId })}
           />
         </Box>
 

--- a/client/src/components/products/filters/StatusFilter.tsx
+++ b/client/src/components/products/filters/StatusFilter.tsx
@@ -15,9 +15,6 @@ export const StatusFilter: FC<StatusFilterProps> = ({ value, onChange }) => {
       sx={{
         minWidth: 200,
         borderRadius: '8px',
-        boxShadow: 1,
-        border: 'none',
-        outline: 'none',
       }}
     >
       <Select

--- a/client/src/components/products/filters/types.ts
+++ b/client/src/components/products/filters/types.ts
@@ -3,5 +3,5 @@ import { ProductStatus } from '../../../types/enum/product';
 export interface FilterState {
   searchQuery?: string;
   status: ProductStatus | '';
-  brandIds: string[];
+  brandId: string | '';
 }

--- a/client/src/generated/graphql-types.ts
+++ b/client/src/generated/graphql-types.ts
@@ -386,6 +386,7 @@ export type QueryProductTagsArgs = {
 };
 
 export type QueryProductsArgs = {
+  brandId?: InputMaybe<Scalars['String']['input']>;
   limit?: Scalars['Int']['input'];
   page?: Scalars['Int']['input'];
   query?: InputMaybe<Scalars['String']['input']>;
@@ -784,6 +785,7 @@ export type GetProductsQueryVariables = Exact<{
   query?: InputMaybe<Scalars['String']['input']>;
   limit: Scalars['Int']['input'];
   page: Scalars['Int']['input'];
+  brandId?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 export type GetProductsQuery = {
@@ -804,7 +806,7 @@ export type GetProductsQuery = {
       reference: string;
       categories: Array<{ __typename?: 'Categories'; name: string }>;
       tags: Array<{ __typename?: 'Tags'; name: string }>;
-      brand: { __typename?: 'Brands'; name: string };
+      brand: { __typename?: 'Brands'; id: string; name: string };
     }>;
   };
 };
@@ -2203,8 +2205,15 @@ export const GetProductsDocument = gql`
     $query: String
     $limit: Int!
     $page: Int!
+    $brandId: String
   ) {
-    products(page: $page, limit: $limit, status: $status, query: $query) {
+    products(
+      page: $page
+      limit: $limit
+      status: $status
+      query: $query
+      brandId: $brandId
+    ) {
       items {
         id
         name
@@ -2221,6 +2230,7 @@ export const GetProductsDocument = gql`
           name
         }
         brand {
+          id
           name
         }
       }
@@ -2246,6 +2256,7 @@ export const GetProductsDocument = gql`
  *      query: // value for 'query'
  *      limit: // value for 'limit'
  *      page: // value for 'page'
+ *      brandId: // value for 'brandId'
  *   },
  * });
  */

--- a/client/src/graphql/products.ts
+++ b/client/src/graphql/products.ts
@@ -6,8 +6,15 @@ export const GET_PRODUCTS = gql`
     $query: String
     $limit: Int!
     $page: Int!
+    $brandId: String
   ) {
-    products(page: $page, limit: $limit, status: $status, query: $query) {
+    products(
+      page: $page
+      limit: $limit
+      status: $status
+      query: $query
+      brandId: $brandId
+    ) {
       items {
         id
         name
@@ -24,6 +31,7 @@ export const GET_PRODUCTS = gql`
           name
         }
         brand {
+          id
           name
         }
       }

--- a/client/src/pages/ProductsPage.tsx
+++ b/client/src/pages/ProductsPage.tsx
@@ -21,10 +21,12 @@ const ProductsPage: React.FC = () => {
   const queryParams = new URLSearchParams(location.search);
   const searchQuery = queryParams.get('query') || '';
   const [selectedStatus, setSelectedStatus] = useState('');
+  const [selectedBrandId, setSelectedBrandId] = useState('');
   const [viewMode, setViewMode] = useState<ViewMode>('cards');
 
   const handleFiltersChange = (filters: FilterState) => {
     setSelectedStatus(filters.status);
+    setSelectedBrandId(filters.brandId);
   };
 
   return (
@@ -50,7 +52,7 @@ const ProductsPage: React.FC = () => {
         <ToggleButtonGroup
           value={viewMode}
           exclusive
-          onChange={(event, newView) => newView && setViewMode(newView)}
+          onChange={(_event, newView) => newView && setViewMode(newView)}
           aria-label="view mode"
           size="small"
         >
@@ -72,7 +74,7 @@ const ProductsPage: React.FC = () => {
         initialFilters={{
           searchQuery: searchQuery || undefined,
           status: '',
-          brandIds: [],
+          brandId: '',
         }}
       />
 
@@ -80,11 +82,13 @@ const ProductsPage: React.FC = () => {
         <ProductList
           searchQuery={searchQuery || undefined}
           status={selectedStatus || undefined}
+          brandId={selectedBrandId || undefined}
         />
       ) : (
         <ProductTableView
           searchQuery={searchQuery || undefined}
           status={selectedStatus || undefined}
+          brandId={selectedBrandId || undefined}
         />
       )}
     </Box>

--- a/services/graphql-service/src/resolvers/ProductResolver.ts
+++ b/services/graphql-service/src/resolvers/ProductResolver.ts
@@ -124,11 +124,12 @@ export default class ProductsResolver {
     @Arg('page', () => Int, { defaultValue: 1 }) page: number,
     @Arg('limit', () => Int, { defaultValue: 10 }) limit: number,
     @Arg('query', () => String, { nullable: true }) query?: string,
-    @Arg('status', () => String, { nullable: true }) status?: string
+    @Arg('status', () => String, { nullable: true }) status?: string,
+    @Arg('brandId', () => String, { nullable: true }) brandId?: string
   ): Promise<PaginatedProductsResponse> {
     try {
       // Clé composite basée sur tous les paramètres
-      const cacheKey = `products:list:page:${page}:limit:${limit}:query:${query || 'null'}:status:${status || 'null'}`;
+      const cacheKey = `products:list:page:${page}:limit:${limit}:query:${query || 'null'}:status:${status || 'null'}:brandId:${brandId || 'null'}`;
 
       // Vérifier le cache
       const cachedResponse =
@@ -146,6 +147,10 @@ export default class ProductsResolver {
 
       if (query) {
         where.name = ILike(`%${query}%`);
+      }
+
+      if (brandId) {
+        where.brand = { id: brandId };
       }
 
       const [items, total] = await Products.findAndCount({


### PR DESCRIPTION
# Replace Brand Autocomplete with Simple Filter

## Overview
This PR replaces the brand autocomplete component with a simpler dropdown filter, making it consistent with the status filter and improving the user experience.

## Changes
- Modified `BrandFilter.tsx` to use a simple dropdown instead of autocomplete
- Updated `FilterContainer.tsx` to handle single brand selection
- Changed `FilterState` to use `brandId` instead of `brandIds` array
- Fixed the backend resolver to properly filter products by brand ID
- Added appropriate caching with Redis for filtered results

## Testing
- Tested filtering by brand with multiple brands
- Verified that filtering works correctly when combined with status filter
- Confirmed that clearing the filter shows all products again
- Checked cache invalidation when products are updated
